### PR TITLE
Add optional `serde` support for `Rational`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ serde = ["dep:serde"]
 [dev-dependencies]
 num-rational = "0.4.2"
 rand = "0.8.3"
+serde_json = "1.0.136"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ serde = ["dep:serde"]
 [dev-dependencies]
 num-rational = "0.4.2"
 rand = "0.8.3"
-serde_json = "1.0.136"
+serde_json = { version = "1.0.136", features = ["arbitrary_precision"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "rational"
 description = "Minimalistic library for rational numbers"
 version = "1.6.0"
 authors = ["Isak Jägberg <ijagberg@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 keywords = ["rational", "ratio", "fraction", "fractions"]
 categories = ["mathematics", "science"]
@@ -12,9 +12,11 @@ homepage = "https://github.com/ijagberg/rational"
 
 [dependencies]
 num-traits = { version = "0.2.16", optional = true }
+serde = { version = "1.0.186", optional = true }
 
 [features]
 num-traits = ["dep:num-traits"]
+serde = ["dep:serde"]
 
 [dev-dependencies]
 num-rational = "0.4.2"

--- a/README.md
+++ b/README.md
@@ -46,3 +46,4 @@ assert_eq!(fractional, Rational::new(2, 3));
 ## Features
 
 - `num-traits`: Enables implementations of many of the traits defined in the `num-traits` crate for `Rationals`
+- `serde`: Enables `Deserialize` and `Serialize` implementations for `Rational`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@ mod ops;
 
 #[cfg(feature = "num-traits")]
 mod num;
+#[cfg(feature = "serde")]
+mod serde;
 
 use extras::gcd;
 use std::{

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,77 @@
+use crate::Rational;
+use serde::{
+    de::{Deserialize, Deserializer, Error, Visitor},
+    ser::{Serialize, Serializer},
+};
+use std::fmt::{self, Formatter};
+
+struct RationalVisitor;
+
+impl Visitor<'_> for RationalVisitor {
+    type Value = Rational;
+
+    fn expecting(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str("a rational number")
+    }
+
+    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        self.visit_i128(v.into())
+    }
+
+    fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(Rational::integer(v))
+    }
+
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        self.visit_i128(v.into())
+    }
+
+    fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        self.visit_i128(v.try_into().map_err(|err| {
+            E::custom(format_args!(
+                "expected a value that fits a signed i128: {err}"
+            ))
+        })?)
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        v.parse().map_err(|err| E::custom(err))
+    }
+}
+
+impl<'de> Deserialize<'de> for Rational {
+    fn deserialize<D>(deserializer: D) -> Result<Rational, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(RationalVisitor)
+    }
+}
+
+impl Serialize for Rational {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if self.is_integer() {
+            serializer.serialize_i128(self.numerator)
+        } else {
+            serializer.serialize_str(&self.to_string())
+        }
+    }
+}

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -79,3 +79,31 @@ impl Serialize for Rational {
         }
     }
 }
+
+macro_rules! test_case {
+    ($name:ident, $value:expr, $str:expr) => {
+        #[cfg(test)]
+        mod $name {
+            use crate::Rational;
+
+            #[test]
+            fn test_serialize() {
+                assert_eq!(serde_json::to_string(&$value).unwrap(), $str);
+            }
+
+            #[test]
+            fn test_deserialize() {
+                assert_eq!(serde_json::from_str::<Rational>($str).unwrap(), $value);
+            }
+        }
+    };
+}
+
+test_case!(zero, Rational::zero(), "0");
+test_case!(one, Rational::one(), "1");
+test_case!(minus_one, -Rational::one(), "-1");
+test_case!(
+    very_big,
+    Rational::integer(i128::MAX),
+    i128::MAX.to_string().as_str()
+);

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -69,7 +69,11 @@ impl Serialize for Rational {
         S: Serializer,
     {
         if self.is_integer() {
-            serializer.serialize_i128(self.numerator)
+            if let Ok(i) = i64::try_from(self.numerator) {
+                serializer.serialize_i64(i)
+            } else {
+                serializer.serialize_i128(self.numerator)
+            }
         } else {
             serializer.serialize_str(&self.to_string())
         }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -88,12 +88,14 @@ macro_rules! test_case {
 
             #[test]
             fn test_serialize() {
-                assert_eq!(serde_json::to_string(&$value).unwrap(), $str);
+                const ERR: &str = concat!("Error trying to serialize ", stringify!($value));
+                assert_eq!(serde_json::to_string(&$value).expect(ERR), $str);
             }
 
             #[test]
             fn test_deserialize() {
-                assert_eq!(serde_json::from_str::<Rational>($str).unwrap(), $value);
+                const ERR: &str = concat!("Error trying to deserialize ", stringify!($str));
+                assert_eq!(serde_json::from_str::<Rational>($str).expect(ERR), $value);
             }
         }
     };
@@ -105,5 +107,5 @@ test_case!(minus_one, -Rational::one(), "-1");
 test_case!(
     very_big,
     Rational::integer(i128::MAX),
-    i128::MAX.to_string().as_str()
+    "170141183460469231731687303715884105727"
 );


### PR DESCRIPTION
This PR allows (de)serializing rationals using serde. If the rational is representable as an integer, we serialize it as such, otherwise as a string displaying the fraction.